### PR TITLE
Use the Head request instead of Get

### DIFF
--- a/services/get_http_headers.go
+++ b/services/get_http_headers.go
@@ -5,7 +5,7 @@ import (
 )
 
 func GetHttpHeaders(url string) Headers {
-	resp, err := http.Get(url)
+	resp, err := http.Head(url)
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
Since we don't need the body content to scan the headers, we can use the HEAD request instead of GET and only get the headers back. This will require the time it will take to get the content back and reduce the size of the response object being sent.